### PR TITLE
[feature/TASK1-51] 게시판 페이지, 상세페이지, 작성페이지, 수정페이지 routing 처리

### DIFF
--- a/app/(pages)/(board)/qna/[id]/layout.tsx
+++ b/app/(pages)/(board)/qna/[id]/layout.tsx
@@ -1,0 +1,3 @@
+import QuestionPage from './page';
+
+export default QuestionPage;

--- a/app/(pages)/(board)/qna/[id]/page.tsx
+++ b/app/(pages)/(board)/qna/[id]/page.tsx
@@ -1,0 +1,45 @@
+import { Metadata } from 'next';
+import dayjs from 'dayjs';
+import { Post } from '@/app/types/data';
+
+type Props = {
+  params: { id: string };
+  post: Post;
+};
+
+const post = await (async function (): Promise<Post> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        id: 1,
+        date: dayjs(),
+        title: '안녕하세요. 궁금한게 있습니다.',
+        content: '본문 내용입니다.',
+        nickname: 'ohdal',
+        modified: false,
+        solved: false,
+      });
+    }, 1000);
+  });
+})();
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const id = params.id;
+
+  return {
+    title: `CO:LON | ${post.title}`,
+    description: 'QnA 상세 페이지 | desc 설정 필요',
+  };
+}
+
+const QuestionPage = (props: Props) => {
+  return (
+    <article>
+      <p>{post.title}</p>
+      <p>{post.nickname}</p>
+      <p>{post.content}</p>
+    </article>
+  );
+};
+
+export default QuestionPage;

--- a/app/(pages)/(board)/qna/[id]/page.tsx
+++ b/app/(pages)/(board)/qna/[id]/page.tsx
@@ -1,13 +1,15 @@
 import { Metadata } from 'next';
 import dayjs from 'dayjs';
 import { Post } from '@/app/types/data';
+import SectionComp from '@/app/components/common/SectionComp';
 
 type Props = {
   params: { id: string };
   post: Post;
 };
 
-const post = await (async function (): Promise<Post> {
+const fetchPost = async (id: string): Promise<Post> => {
+  // TODO: get post api 연동
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve({
@@ -21,10 +23,12 @@ const post = await (async function (): Promise<Post> {
       });
     }, 1000);
   });
-})();
+};
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const id = params.id;
+
+  const post = await fetchPost(id);
 
   return {
     title: `CO:LON | ${post.title}`,
@@ -32,13 +36,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-const QuestionPage = (props: Props) => {
+const QuestionPage = async (props: Props) => {
+  const { params } = props;
+
+  const post = await fetchPost(params.id);
+
   return (
-    <article>
-      <p>{post.title}</p>
-      <p>{post.nickname}</p>
-      <p>{post.content}</p>
-    </article>
+    <SectionComp direction="column">
+      <article>
+        <p>{post.title}</p>
+        <p>{post.nickname}</p>
+        <p>{post.content}</p>
+      </article>
+    </SectionComp>
   );
 };
 

--- a/app/(pages)/(board)/qna/layout.tsx
+++ b/app/(pages)/(board)/qna/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+import QnaPage from './page';
+
+export const metadata: Metadata = {
+  title: 'CO:LON | QnA 게시판 페이지',
+  description: 'QnA 게시판 페이지 | desc 설정 필요',
+};
+
+export default QnaPage;

--- a/app/(pages)/(board)/qna/page.tsx
+++ b/app/(pages)/(board)/qna/page.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+import SectionComp from '@/app/components/common/SectionComp';
+
+interface Props {
+  children: ReactNode;
+}
+
+const QnaPage = (props: Props) => {
+  const { children } = props;
+
+  return <main>{children || <SectionComp direction="column">QnA 게시판 페이지</SectionComp>}</main>;
+};
+
+export default QnaPage;

--- a/app/(pages)/(board)/qna/write/layout.tsx
+++ b/app/(pages)/(board)/qna/write/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+import WritePage from './page';
+
+export const metadata: Metadata = {
+  title: 'CO:LON | QnA 글 작성 페이지',
+  description: 'QnA 글 작성 페이지 | desc 설정 필요',
+};
+
+export default WritePage;

--- a/app/(pages)/(board)/qna/write/page.tsx
+++ b/app/(pages)/(board)/qna/write/page.tsx
@@ -1,7 +1,13 @@
 import SectionComp from '@/app/components/common/SectionComp';
+import Writecomp from '@/app/components/board/qna/write/WriteComp';
 
 const WritePage = () => {
-  return <SectionComp direction="column">QnA 게시글 작성 페이지</SectionComp>;
+  return (
+    <SectionComp direction="column">
+      QnA 게시글 작성 페이지
+      <Writecomp />
+    </SectionComp>
+  );
 };
 
 export default WritePage;

--- a/app/(pages)/(board)/qna/write/page.tsx
+++ b/app/(pages)/(board)/qna/write/page.tsx
@@ -1,0 +1,5 @@
+const WritePage = () => {
+  return <div>QnA 게시글 작성 페이지</div>;
+};
+
+export default WritePage;

--- a/app/(pages)/(board)/qna/write/page.tsx
+++ b/app/(pages)/(board)/qna/write/page.tsx
@@ -1,5 +1,7 @@
+import SectionComp from '@/app/components/common/SectionComp';
+
 const WritePage = () => {
-  return <div>QnA 게시글 작성 페이지</div>;
+  return <SectionComp direction="column">QnA 게시글 작성 페이지</SectionComp>;
 };
 
 export default WritePage;

--- a/app/components/board/qna/write/WriteComp.tsx
+++ b/app/components/board/qna/write/WriteComp.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import dayjs from 'dayjs';
+import { Post } from '@/app/types/data';
+
+const fetchPost = async (id: string): Promise<Post> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        id: 1,
+        date: dayjs(),
+        title: '안녕하세요. 궁금한게 있습니다.',
+        content: '본문 내용입니다.',
+        nickname: 'ohdal',
+        modified: false,
+        solved: false,
+      });
+    }, 1000);
+  });
+};
+
+export const Writecomp = () => {
+  // id 값이 있다면 수정모드
+  const searchParams = useSearchParams();
+  const id = searchParams.get('id');
+  const [post, setPost] = useState<Post | null>(null);
+
+  const getPost = async (id: string) => {
+    // TODO: get post api 연동
+    const data = await fetchPost(id);
+    setPost(data);
+  };
+
+  useEffect(() => {
+    if (id) getPost(id);
+  }, []);
+
+  return <div>WriteComp</div>;
+};
+
+export default Writecomp;


### PR DESCRIPTION
작업내용.
- feat: 게시판, 게시판 상세 페이지, 게시글 작성 페이지 라우팅.
- feat: 게시판 상세 페이지, 동적 메타태그 설정.
- feat: 게시글 수정 페이지 처리 WriteComp.tsx 예제 작성.

참고사항.
- 라우팅을 추후 다른 카테고리의 게시판 추가를 고려하여 (board)/qna/... 형식으로 구성하였습니다. 피그마 스토리보드 IA를 참고하며 진행했는데, 상세 페이지는 qna/question/id 식으로 가면 URL이 길어진다 생각해서 qna/[id]로 구성했습니다.
- 게시글 작성, 수정 페이지 차이점이 데이터 초기화를 해주는것 밖에 없다고 생각해서, useSerachParams를 이용하여 id값의 존재 여부에따라 WriteComp.tsx 내에서 로직을 분리하는식으로 진행하면 좋을것 같다고 생각하며 작업했습니다.
- 상세 페이지에서 SEO를 고려한 동적 메타태그 설정을 위해 NextJS 공식문서를 참고하여 작업했습니다. NextJS fetch가 캐시를 지원해서 메타태그 설정을 위해, 페이지 내 게시글을 위해 api를 두번 호출하였습니다.