### PR TITLE
[feature/TASK1-88] 탈퇴하기 api 연동

### DIFF
--- a/app/(pages)/mypage/page.tsx
+++ b/app/(pages)/mypage/page.tsx
@@ -4,6 +4,7 @@ import Tabs from '@/app/components/common/TabsComp';
 import ReactionContent from '@/app/components/mypage/ReactionContent';
 import ScrapContent from '@/app/components/mypage/ScrapContent';
 import ActivityContent from '@/app/components/mypage/ActivityContent';
+import DeleteUserButton from '@/app/components/mypage/DeleteUserButton';
 
 const tabList = [
   { text: '반응한 글', component: <ReactionContent /> },
@@ -27,6 +28,8 @@ export default function MyPage() {
       <SectionComp direction="column">
         <Tabs tabList={tabList} />
       </SectionComp>
+
+      <DeleteUserButton />
     </main>
   );
 }

--- a/app/components/auth/signup/SignUpFormComp.tsx
+++ b/app/components/auth/signup/SignUpFormComp.tsx
@@ -135,11 +135,11 @@ const SignUpFormComp = () => {
     signUp({
       major: major as JOB_GROUP_TYPES,
       profileUrl: isKaKaoProfile
-        ? userInfo?.kakaoUserInfo.avatar_url ?? ''
-        : userInfo?.user.profile_url ?? '',
+        ? userInfo?.kakaoUserInfo?.avatar_url ?? ''
+        : userInfo?.user?.profile_url ?? '',
       nickname: isKaKaoProfile ? kakaoNickname : randomNickName,
     });
-  }, [isDisable]);
+  }, [isDisable, profile]);
 
   const handleRefreshRandomNickName = async () => {
     const { data: randomNickName } = await refetchNickName();

--- a/app/components/mypage/DeleteUserButton.tsx
+++ b/app/components/mypage/DeleteUserButton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import styled from 'styled-components';
+import useAuth from '@/app/hooks/useAuth';
+import { useRouter } from 'next/navigation';
+
+const DeleteButton = styled.button`
+  float: right;
+  background: none;
+  text-decoration: underline;
+`;
+
+const DeleteUserButton = () => {
+  const { deleteUser } = useAuth();
+  const { push } = useRouter();
+
+  const handleClick = async () => {
+    // TODO: 팝업창 띄우기
+
+    await deleteUser();
+    push('/');
+  };
+
+  return <DeleteButton onClick={handleClick}>탈퇴하기</DeleteButton>;
+};
+
+export default DeleteUserButton;


### PR DESCRIPTION
작업내용.
- feat: DeleteUserButton.tsx 추가
- fix: 회원가입 오류 수정.

참고사항.
탈퇴하고 다시 회원가입을 진행하는 과정에서 오류를 발견하여 수정했습니다 🙇🏻‍♀️ 발견된 오류는 아래 두가지 입니다 !
1. SignUpFormComp.tsx 컴포넌트 handleClick 함수에서 useCallback dependency list에 profile이 추가 되지 않아, 랜덤 프로필을 선택했음에도 isKaKaoProfile이 계속 true인 오류.
2. SignUpFormComp.tsx 컴포넌트 useAuth hook의 signUp호출 과정에서 profileUrl 값을 집어넣을때 옵셔널 체이닝을 해주지 않아 발생한 오류.