### PR TITLE
[feature/TASK1-109] history api

### DIFF
--- a/app/api/auth/history/fetch.ts
+++ b/app/api/auth/history/fetch.ts
@@ -1,0 +1,7 @@
+import { GetHistoryQuery, GetHistoryResponse } from './type';
+
+export const fetchGetHistory = async ({ historyType }: GetHistoryQuery) => {
+  const res = await fetch(`/api/auth/history?historyType=${historyType}`);
+  const jsonData = (await res.json()) as GetHistoryResponse;
+  return jsonData;
+};

--- a/app/api/auth/history/queries.ts
+++ b/app/api/auth/history/queries.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import supabaseClient from '@/app/utils/supabase/client';
+import QUERY_KEYS from '../../queryKeys';
+import { GetHistoryQuery } from './type';
+import { fetchGetHistory } from './fetch';
+
+const useHistoryQuery = ({ historyType }: GetHistoryQuery) => {
+  const { auth } = supabaseClient;
+
+  return useQuery({
+    queryKey: QUERY_KEYS.historyList({ historyType }),
+    queryFn: () => fetchGetHistory({ historyType }),
+    enabled: !!auth.getSession(),
+  });
+};
+
+export default useHistoryQuery;

--- a/app/api/auth/history/route.ts
+++ b/app/api/auth/history/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/app/utils/supabase/server';
+import { getHost } from '@/app/utils/host';
+import { HISTORY_TYPES } from './type';
+import { PostListItem } from '../../post/type';
+import { GetCommentsResponseItem } from '../../comment/[postId]/type';
+
+export async function GET(request: NextRequest, response: Response) {
+  const host = getHost();
+
+  const supabase = await createClient();
+
+  const searchParams = request.nextUrl.searchParams;
+  const historyType = searchParams.get('historyType') as HISTORY_TYPES;
+
+  try {
+    const { data, error: sessionError } = await supabase.auth.getSession();
+    if (sessionError) {
+      return NextResponse.json({ success: false, sessionError });
+    }
+
+    const userId = data.session?.user.id;
+
+    const postQuery = supabase.from('posts').select('*').eq('user_id', userId);
+    const commentQuery = supabase
+      .from('comments')
+      .select(
+        '*, posts!comments_post_id_fkey ( id, status, title, preview_body, author_major, requested_major, author_nickname )',
+      )
+      .eq('user_id', userId);
+
+    // 활동내역 list
+    if (historyType === 'ACTIVITY') {
+      const { data: postHistory, error: postGetError } = await postQuery;
+
+      if (postGetError) {
+        return NextResponse.json({ success: false, postGetError });
+      }
+
+      const postHistoryList = postHistory.map((post: PostListItem) => {
+        const {
+          id,
+          status,
+          requested_major,
+          author_major,
+          author_nickname,
+          title,
+          preview_body,
+          updated_at,
+        } = post;
+        return {
+          type: 'POST',
+          post: {
+            postId: id,
+            postStatus: status,
+            postAuthorMajor: author_major,
+            postRequestedMajor: requested_major,
+            authorNickname: author_nickname,
+            title,
+            previewBody: preview_body,
+          },
+          updatedAt: updated_at,
+        };
+      });
+
+      const { data: commentHistory, error: commentGetError } = await commentQuery;
+
+      if (commentGetError) {
+        return NextResponse.json({ success: false, commentGetError });
+      }
+
+      const commentHistoryList = commentHistory.map((commentItem) => {
+        const { id, author_major, author_nickname, comment, updated_at, posts } = commentItem;
+        const {
+          id: postId,
+          status: postStatus,
+          title,
+          preview_body,
+          author_major: postAuthorMajor,
+          requested_major: postRequestedMajor,
+          author_nickname: authorNickname,
+        } = posts;
+
+        return {
+          type: 'COMMENT',
+          post: {
+            postId,
+            postStatus,
+            postAuthorMajor,
+            postRequestedMajor,
+            authorNickname,
+            title,
+            previewBody: preview_body,
+          },
+          comment: {
+            commentId: id,
+            commentAuthorMajor: author_major,
+            commentAuthorNickname: author_nickname,
+            comment,
+          },
+          updatedAt: updated_at,
+        };
+      });
+
+      const res = [...postHistoryList, ...commentHistoryList];
+      res.sort((prev, next) => (prev.updatedAt < next.updatedAt ? 1 : -1));
+
+      return NextResponse.json({
+        success: true,
+        list: res,
+      });
+    }
+
+    return NextResponse.json({ success: true, list: [] });
+  } catch (error) {
+    return NextResponse.redirect(`${host}/error/500`);
+  }
+}
+
+export async function POST(request: Request) {
+  const host = getHost();
+
+  const supabase = await createClient();
+  const bodyData = await request.json();
+
+  try {
+    const { error } = await supabase.from('user_info').insert([{ ...bodyData }]);
+    // TODO: error 처리 프론트 or 백 결정 필요.
+    return NextResponse.json({ success: error ? false : true });
+  } catch (error) {
+    return NextResponse.redirect(`${host}/error/500`);
+  }
+}
+
+export async function PUT(request: Request) {
+  const host = getHost();
+
+  const supabase = await createClient();
+  const bodyData = await request.json();
+
+  try {
+    const { data } = await supabase.auth.getSession();
+    const { error } = await supabase
+      .from('user_info')
+      .update({ ...bodyData })
+      .eq('user_id', data.session?.user.id);
+    // TODO: error 처리 프론트 or 백 결정 필요.
+    return NextResponse.json({ success: error ? false : true, error });
+  } catch (error) {
+    return NextResponse.redirect(`${host}/error/500`);
+  }
+}

--- a/app/api/auth/history/type.d.ts
+++ b/app/api/auth/history/type.d.ts
@@ -1,0 +1,35 @@
+import { Session } from '@supabase/supabase-js';
+import dayjs from 'dayjs';
+import { JOB_GROUP_TYPES } from '../user/type';
+import { POST_STATUS_TYPES } from '../../post/type';
+
+export type HISTORY_TYPES = 'REACTIONS' | 'SCRAP' | 'ACTIVITY';
+
+export interface GetHistoryQuery {
+  historyType: HISTORY_TYPES;
+}
+
+export interface HistoryItemProps {
+  type: 'POST' | 'COMMENT';
+  post: {
+    postId: number;
+    postStatus?: POST_STATUS_TYPES;
+    postAuthorMajor: JOB_GROUP_TYPES;
+    postRequestedMajor: JOB_GROUP_TYPES | 'ALL';
+    authorNickname: string;
+    title: string;
+    previewBody: string;
+  };
+  comment?: {
+    commentId?: number;
+    commentAuthorMajor?: JOB_GROUP_TYPES;
+    commentAuthorNickname?: string;
+    comment?: string;
+  };
+  updatedAt: string;
+}
+
+export interface GetHistoryResponse extends Session {
+  success: boolean;
+  list: HistoryItemProps[];
+}

--- a/app/api/post/type.d.ts
+++ b/app/api/post/type.d.ts
@@ -4,7 +4,7 @@ import { JOB_GROUP_TYPES } from '../auth/user/type';
 export type POST_STATUS_TYPES = 'EDITING' | 'COMPLETE';
 
 export interface InsertPostRequest {
-  status: POST_STATUS;
+  status: POST_STATUS_TYPES;
   requested_major: JOB_GROUP_TYPES | 'ALL';
   title: string;
   body: string;
@@ -29,7 +29,7 @@ export interface GetPostListQuery {
 
 export interface PostListItem {
   id: number;
-  status: POST_STATUS;
+  status: POST_STATUS_TYPES;
   requested_major: JOB_GROUP_TYPES;
   title: string;
   body: string;

--- a/app/api/queryKeys.ts
+++ b/app/api/queryKeys.ts
@@ -1,3 +1,4 @@
+import { GetHistoryQuery } from './auth/history/type';
 import { GetPostListQuery } from './post/type';
 
 const authUserSession = ['auth', 'user'];
@@ -11,6 +12,7 @@ const postList = ({ order, major }: Omit<GetPostListQuery, 'offset'>) => [
 ];
 const postSearch = (word: string) => ['post', `/${word}`];
 const commentList = (postId: string) => ['comment', `/${postId}`];
+const historyList = ({ historyType }: GetHistoryQuery) => ['history', `/${historyType}`];
 
 const QUERY_KEYS = {
   authUserSession,
@@ -19,6 +21,7 @@ const QUERY_KEYS = {
   postSearch,
   postList,
   commentList,
+  historyList,
 };
 
 export default QUERY_KEYS;


### PR DESCRIPTION
작업내용.
 - fix: post type 오탈자 수정.
 - feat: history api type, route, query, fetch, key 추가.

참고사항.
- 스크랩, 반응한 글은 기능 구현이 되어있지 않아 활동 내역만 개발된 상태입니다.
- 전체 / 글 / 댓글 / 임시저장은 프론트에서 필터링하는게 더 효과적일듯해 전체 데이터를 response 하도록 했습니다.