### PR TITLE
[feature/TASK1-190] 댓글 정렬 기능 추가

### DIFF
--- a/app/(pages)/examples/questionCard/page.tsx
+++ b/app/(pages)/examples/questionCard/page.tsx
@@ -21,6 +21,7 @@ export default function Home() {
         author_profile_url="/"
         isScrap
         comments_count={999}
+        accept_comment_id={0}
       />
     </main>
   );

--- a/app/api/comment/[postId]/queries.ts
+++ b/app/api/comment/[postId]/queries.ts
@@ -1,19 +1,21 @@
-import { useQuery } from '@tanstack/react-query';
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import QUERY_KEYS from '../../queryKeys';
 import { fetchGetComments } from './fetch';
+import { GetCommentsResponseItem } from './type';
 
-const useCommentsQuery = (postId: string) =>
+const useCommentsQuery = (postId: string): UseQueryResult<GetCommentsResponseItem[], Error> =>
   useQuery({
     queryKey: QUERY_KEYS.commentList(postId),
     queryFn: () => fetchGetComments(postId),
     select: (data) => {
       const rootComments = data.data?.filter((comment) => !comment?.original_comment);
 
-      // 대댓글 parsing
-      return rootComments?.map((comment) => ({
+      const newValue = rootComments?.map((comment) => ({
         ...comment,
         nestedComments: data.data.filter(({ original_comment }) => original_comment === comment.id),
       }));
+      // 대댓글 parsing
+      return newValue as GetCommentsResponseItem[];
     },
   });
 

--- a/app/api/comment/[postId]/type.d.ts
+++ b/app/api/comment/[postId]/type.d.ts
@@ -13,7 +13,7 @@ export interface GetCommentsResponseItem {
   reaction_count: number;
 
   // client computed props
-  nestedComments: GetCommentsResponse[];
+  nestedComments: GetCommentsResponseItem[];
 }
 
 export interface GetCommentsResponse {

--- a/app/api/post/type.d.ts
+++ b/app/api/post/type.d.ts
@@ -42,6 +42,7 @@ export interface PostListItem {
   author_major: JOB_GROUP_TYPES;
   author_profile_url: string;
   comments_count: number;
+  accept_comment_id: number;
 }
 
 export interface GetPostListResponse {

--- a/app/components/board/qna/QnADetail/QnACommentList.tsx
+++ b/app/components/board/qna/QnADetail/QnACommentList.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import useCommentsQuery from '@/app/api/comment/[postId]/queries';
-import { IMAGE_CDN } from '@/app/constants/externalUrls';
 import useAuth from '@/app/hooks/useAuth';
-import Image from 'next/image';
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import CommentItem from './CommentItem';
+import Selector from '@/app/components/common/Selector';
+import { isEmpty } from 'lodash';
+import { GetCommentsResponseItem } from '@/app/api/comment/[postId]/type';
 
 interface Props {
   postId: string;
@@ -31,43 +32,62 @@ const TitleP = styled.p`
   ${({ theme }) => theme.font.body2};
 `;
 
-const SelectButton = styled.button`
-  display: flex;
-  align-items: center;
-  background-color: transparent;
-  padding: 4px 8px;
-  ${({ theme }) => theme.font.body3};
-
-  & > span {
-    margin-right: 4px;
-  }
-`;
-
 const QnACommentList = ({ postId, acceptedCommentId, postAuthor }: Props) => {
+  const [commentList, setCommentList] = useState<GetCommentsResponseItem[]>([]);
+
   const { data } = useCommentsQuery(postId);
 
   const { userInfo } = useAuth();
 
   const isAuthor = useMemo(() => postAuthor === userInfo?.user.nick_name, [userInfo]);
 
+  const handleSortList = useCallback(
+    (type: 'updated' | 'reaction') => {
+      const nextList = [...commentList];
+
+      if (type === 'updated') {
+        nextList.sort((_prev, _next) => (_prev.id > _next.id ? 1 : -1));
+      }
+
+      if (type === 'reaction') {
+        nextList.sort((_prev, _next) => (_prev.reaction_count > _next.reaction_count ? -1 : 1));
+      }
+
+      setCommentList(nextList);
+    },
+    [commentList],
+  );
+
+  useEffect(() => {
+    if (data && !isEmpty(data) && isEmpty(commentList)) {
+      setCommentList(data);
+    }
+  }, [data]);
+
   return (
     <ConatinerDiv>
       <FilterDiv>
         <TitleP>댓글</TitleP>
-        {/* TODO: selector 컴포넌트 제작 필요 */}
-        <SelectButton>
-          <span>정렬</span>
-          <Image
-            alt="정렬 아이콘"
-            src={`${IMAGE_CDN}/icon/chevron-down.png`}
-            width={8}
-            height={4.5}
+        <Selector defaultOption={{ idx: 0, text: '정렬' }}>
+          <Selector.Option
+            idx={0}
+            text="최신순"
+            clickEvent={() => {
+              handleSortList('updated');
+            }}
           />
-        </SelectButton>
+          <Selector.Option
+            idx={1}
+            text="반응순"
+            clickEvent={() => {
+              handleSortList('reaction');
+            }}
+          />
+        </Selector>
       </FilterDiv>
 
       <ul>
-        {data?.map(
+        {commentList?.map(
           ({
             id,
             author_nickname,

--- a/app/components/board/qna/QnADetail/QnADetailContent.tsx
+++ b/app/components/board/qna/QnADetail/QnADetailContent.tsx
@@ -138,6 +138,7 @@ const QnADetailContent = ({ post }: Props) => {
     author_nickname,
     author_major,
     comments_count,
+    accept_comment_id,
   } = post;
 
   // TODO: tanstack query hydrate 적용 필요.
@@ -148,7 +149,7 @@ const QnADetailContent = ({ post }: Props) => {
   const { push, replace } = useRouter();
   const { userInfo } = useAuth();
 
-  const isComplete = useMemo(() => status === 'COMPLETE', []);
+  const isComplete = useMemo(() => status === 'COMPLETE' && !!accept_comment_id, []);
   const isScrap = useMemo(
     () => userScrapData?.list.find((item) => item.post_id === id),
     [userScrapData],

--- a/app/components/board/qna/QnaListComp.tsx
+++ b/app/components/board/qna/QnaListComp.tsx
@@ -94,6 +94,7 @@ const QnaListComp = () => {
             author_major,
             author_profile_url,
             comments_count,
+            accept_comment_id,
           } = post;
 
           const isScrap = userScrapData?.list.find((item) => item.post_id === id);
@@ -117,6 +118,7 @@ const QnaListComp = () => {
                     author_profile_url={author_profile_url}
                     isScrap={!!isScrap}
                     comments_count={comments_count}
+                    accept_comment_id={accept_comment_id}
                   />
                 </Link>
               </div>
@@ -139,6 +141,7 @@ const QnaListComp = () => {
                   author_profile_url={author_profile_url}
                   isScrap={!!isScrap}
                   comments_count={comments_count}
+                  accept_comment_id={accept_comment_id}
                 />
               </Link>
             </li>

--- a/app/components/common/QuestionCard.tsx
+++ b/app/components/common/QuestionCard.tsx
@@ -155,6 +155,7 @@ const QuestionCard = ({
   author_profile_url,
   isScrap,
   comments_count,
+  accept_comment_id,
 }: Props) => {
   return (
     <ContainerArticle>
@@ -171,7 +172,7 @@ const QuestionCard = ({
             <Image
               alt="답변 체크"
               src={`${IMAGE_CDN}/qna/CheckMarkButton${
-                status === 'COMPLETE' ? '_checked' : '_disable'
+                status === 'COMPLETE' && !!accept_comment_id ? '_checked' : '_disable'
               }.png`}
               width={20}
               height={20}


### PR DESCRIPTION
작업내용.
* - fix: 답변 완료 조건문 수정.
* - fix: useCommentsQuery return type 적용.
* - fix: GetCommentsResponseItem nestedComment type 미스매치 수정.
* - feat: 댓글 정렬 기능 추가.

참고사항.
- selector option 노출시 option 영역 아래에 selector가 있으면 겹쳐져서 보이는 버그 있습니다. 기능없음 그룹의 selector 수정 이슈와 함께 진행하면 좋을듯 합니다.