### PR TITLE
[feature/TASK1-173] 활동내역 영역 댓글, 글, 임시저장 삭제 api 연동

### DIFF
--- a/app/api/auth/history/route.ts
+++ b/app/api/auth/history/route.ts
@@ -27,7 +27,8 @@ export async function GET(request: NextRequest, response: Response) {
       .select(
         '*, posts!comments_post_id_fkey ( id, status, title, preview_body, author_major, requested_major, author_nickname )',
       )
-      .eq('user_id', userId);
+      .eq('user_id', userId)
+      .neq('author_nickname', null);
 
     // 활동내역 list
     if (historyType === 'ACTIVITY') {

--- a/app/api/post/[id]/fetch.ts
+++ b/app/api/post/[id]/fetch.ts
@@ -19,7 +19,7 @@ export const fetchUpdatePost = async (body: UpdatePostRequest) => {
   return jsonData;
 };
 
-export const fetchDeletePost = async (id: string) => {
+export const fetchDeletePost = async (id: number) => {
   const res = await fetch(`/api/post/${id}`, {
     method: 'DELETE',
   });

--- a/app/api/post/[id]/mutations.ts
+++ b/app/api/post/[id]/mutations.ts
@@ -6,4 +6,4 @@ export const useModifyPostMutation = () =>
   useMutation({ mutationFn: (body: UpdatePostRequest) => fetchUpdatePost(body) });
 
 export const useDeletePostMutation = () =>
-  useMutation({ mutationFn: (id: string) => fetchDeletePost(id) });
+  useMutation({ mutationFn: (id: number) => fetchDeletePost(id) });

--- a/app/components/mypage/ActivityContentInner.tsx
+++ b/app/components/mypage/ActivityContentInner.tsx
@@ -99,7 +99,7 @@ const ActivityContentInner = (props: Props) => {
         setFilteredList(list);
         break;
     }
-  }, [filter]);
+  }, [list, filter]);
 
   return (
     <>

--- a/app/components/mypage/ReactionContent.tsx
+++ b/app/components/mypage/ReactionContent.tsx
@@ -65,7 +65,7 @@ const ScarpIcon = styled(Image)`
   transform: translateY(-50%);
 `;
 
-const ReactionContent = async () => {
+const ReactionContent = () => {
   const { data } = useHistoryQuery({ historyType: 'REACTIONS' });
 
   return (


### PR DESCRIPTION
작업 내용.
- fix: 마이페이지 ReactionContent 오류 수정
- feat: 마이페이지 활동내역 글, 임시저장, 댓글 삭제 api 연동
- fix: history GET api ACTIVITY type 삭제된 코멘트 안가져오도록 쿼리 수정

참고 사항.
- ReactionContent 컴포넌트가 'use client'를 작성해주고 동시에 잘못 서버 컴포넌트로 사용하려고 해서 오류가 생기길래 수정해주었습니다.
- 댓글 데이터가 DB에서 아예 삭제가 되는게 아니라서 활동내역 영역에 '삭제된 댓글입니다'로 표기되는 문제 때문에 author_nickname 값이 null 이 아닌 댓글만 가져오도록 쿼리문을 수정했습니다.