### PR TITLE
[bugfix/QA-18] 기본 프로필 유저 글 작성 오류 버그

### DIFF
--- a/app/api/post/route.ts
+++ b/app/api/post/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
           preview_body,
           tags,
           author_major,
-          author_profile_url,
+          author_profile_url: author_profile_url ?? '',
           author_nickname,
           body_url: postData?.path,
           created_at: createdDate,


### PR DESCRIPTION
작업내용.
 - fix: 작성자 프로필이 없을 경우 초기값 할당.