### PR TITLE
[bugfix/QA-17] 댓글 반응하기 선택 후, 재선택시 로그인 모달 잘못 노출되는 현상

### DIFF
--- a/app/api/post/search/type.d.ts
+++ b/app/api/post/search/type.d.ts
@@ -19,7 +19,7 @@ interface PostSearchItemProps {
   // TODO: tanstack hydrate 적용후 select 에서 ReactionsObjType 변환 필요
   reactions: string;
   comments_count: number;
-  accept_comment_id: number;
+  accept_comment_id: number[];
 }
 
 export interface GetPostSearchResponse {

--- a/app/components/board/qna/QnADetail/QnADetailContent.tsx
+++ b/app/components/board/qna/QnADetail/QnADetailContent.tsx
@@ -158,7 +158,7 @@ const QnADetailContent = ({ post }: Props) => {
   );
 
   const handleDeletePost = () => {
-    mutateAsync(id.toString());
+    mutateAsync(id);
     push('/qna');
   };
 

--- a/app/components/common/PostComp/ReactionCount.tsx
+++ b/app/components/common/PostComp/ReactionCount.tsx
@@ -147,7 +147,7 @@ const ReactionCount = ({
     if (reactionDisabled) return;
 
     setIsActive((v) => !v);
-  }, [reactionDisabled]);
+  }, [reactionDisabled, userInfo]);
 
   const handleEmojiClick = useCallback(
     async (emoji: ReactionType) => {


### PR DESCRIPTION
작업내용.
- fix: build fail fix. accept_comment_id number -> number[] type 수정.
- fix: 반응하기 event callback 누락 의존성 userInfo 추가.

참고사항.
- 작업 진행중에 build fail 발견했는데, 따로 이슈파기엔 애매한 정도라 함께 작업해서 올립니다.